### PR TITLE
Fix space in Monte Carlo tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,11 +153,11 @@
     <div class="display">
       <div class="tabs">
         <button data-tab="plot" class="active">Time Series</button>
-        <button data-tab="montecarlo">Monte Carlo</button>
+        <button data-tab="montecarlo">Monte Carlo</button>
         <button data-tab="table">Table</button>
         <button data-tab="sensitivity">Sensitivity</button>
         <button data-tab="pareto">Pareto</button>
-        <button data-tab="dataView">Data View</button>
+        <button data-tab="dataView">Data View</button>
       </div>
 
       <!-- Time Series Tab -->


### PR DESCRIPTION
## Summary
- replace the non-breaking space in the "Monte Carlo" tab label with a normal space

## Testing
- `grep -n "montecarlo" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6840474d40c08322acbf37f91e24378a