### PR TITLE
Handle uniform histogram case

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,12 @@
     const finals = sim.sims.map(s=>s[s.length-1]);
     const binsCount = 20;
     const minV = Math.min(...finals), maxV = Math.max(...finals);
+    if(maxV === minV){
+      histogramChart.data.labels = [minV.toFixed(0)];
+      histogramChart.data.datasets[0].data = [finals.length];
+      histogramChart.update();
+      return;
+    }
     const w = (maxV - minV)/binsCount;
     const bins = Array(binsCount).fill(0);
     finals.forEach(v=>{


### PR DESCRIPTION
## Summary
- avoid divide-by-zero when all NPV results are identical

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840474f91288322aebf58385d6b7843